### PR TITLE
Force version to node 8.12

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,2 @@
+v8.12.0
+engineStrict=true 

--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
     "truffle": "5.0.26",
     "truffle-hdwallet-provider": "1.0.13",
     "web3": "1.0.0-beta.55"
+  },
+  "engines": {
+    "node": "=8.12.0"
   }
 }


### PR DESCRIPTION
Force to use node 8  if user has nvm https://stackoverflow.com/questions/29349684/how-can-i-specify-the-required-node-js-version-in-package-json#answer-54507679
Because oppen zeppelin os (zos) version in this project, it only works with node 8.12 