### PR TITLE
Use BigNumber when creating fees on js

### DIFF
--- a/test/moc/commissions/MoCDocMintingWithCommissions-test.js
+++ b/test/moc/commissions/MoCDocMintingWithCommissions-test.js
@@ -210,17 +210,13 @@ contract('MoC', function([owner, userAccount, commissionsAccount]) {
           await mocHelper.mocInrate.MINT_BPRO_FEES_MOC()
         );
       });
-      describe('WHEN a user tries to mint 10000 Docs using MoC commission', function() {
+      describe.only('WHEN a user tries to mint 10000 Docs using MoC commission', function() {
         let prevBtcBalance;
-        let prevCommissionsAccountBtcBalance;
         let txCost;
         let prevUserMoCBalance; // If user has MoC balance, then commission fees will be in MoC
         let prevCommissionsAccountMoCBalance;
         beforeEach(async function() {
           prevBtcBalance = toContractBN(await web3.eth.getBalance(userAccount));
-          prevCommissionsAccountBtcBalance = toContractBN(
-            await web3.eth.getBalance(commissionsAccount)
-          );
           prevUserMoCBalance = await mocHelper.getMoCBalance(userAccount);
           prevCommissionsAccountMoCBalance = await mocHelper.getMoCBalance(commissionsAccount);
 
@@ -235,7 +231,7 @@ contract('MoC', function([owner, userAccount, commissionsAccount]) {
           // commission = 5000 * 0.009
           const btcBalance = toContractBN(await web3.eth.getBalance(userAccount));
           const diff = prevBtcBalance.sub(toContractBN(btcBalance)).sub(new BN(txCost));
-          const expectedMoCCommission = 4500000000000000;
+          const expectedMoCCommission = '4500000000000000';
           const diffAmountMoC = new BN(prevUserMoCBalance).sub(new BN(expectedMoCCommission));
 
           mocHelper.assertBig(diff, '500000000000000000', 'Balance does not decrease by 0.5 RBTC');
@@ -246,47 +242,52 @@ contract('MoC', function([owner, userAccount, commissionsAccount]) {
             'Balance in MoC does not decrease by 0.0045 MoC'
           );
         });
-        // it('AND User only spent on comissions for 0.0045 MoC', async function() {
-        //   const btcBalance = toContractBN(await web3.eth.getBalance(userAccount));
-        //   const userMoCBalance = toContractBN(await mocHelper.getMoCBalance(userAccount));
-        //   const diff = prevBtcBalance
-        //     .sub(toContractBN(btcBalance))
-        //     .sub(new BN(txCost))
-        //     .sub(toContractBN(500000000000000000));
-        //   const expectedMoCCommission = 4500000000000000;
-        //   const diffCommissionMoC = new BN(prevUserMoCBalance).sub(new BN(userMoCBalance));
+        it('AND User only spent on comissions for 0.0045 MoC', async function() {
+          const btcBalance = await web3.eth.getBalance(userAccount);
+          const userMoCBalance = await mocHelper.getMoCBalance(userAccount);
+          const diff = prevBtcBalance
+            .sub(toContractBN(btcBalance))
+            .sub(txCost)
+            .sub(toContractBN('500000000000000000'));
+          const expectedMoCCommission = '4500000000000000';
+          const diffCommissionMoC = new BN(prevUserMoCBalance).sub(new BN(userMoCBalance));
 
-        //   console.log("prevUserMoCBalance: ", prevUserMoCBalance.toString());
-        //   console.log("userMoCBalance: ", userMoCBalance.toString());
-        //   console.log("diffCommissionMoC: ", diffCommissionMoC.toString());
+          console.log("mocHelper.mocInrate.MINT_DOC_FEES_MOC(): ", (await mocHelper.mocInrate.MINT_DOC_FEES_MOC()).toString());
+          console.log("mocHelper.mocInrate.commissionRatesByTxType(9): ", (await mocHelper.mocInrate.commissionRatesByTxType(9)).toString());
+          console.log("mocHelper.mocInrate.calcComissionValue(): ", (await mocHelper.mocInrate.calcCommissionValue('1000000000000000000',9)).toString());
+          console.log("prevUserMoCBalance: ", prevUserMoCBalance.toString());
+          console.log("userMoCBalance: ", userMoCBalance.toString());
+          console.log("diffCommissionMoC: ", diffCommissionMoC.toString());
 
-        //   mocHelper.assertBig(
-        //     diff,
-        //     0,
-        //     'RBTC balance should not decrease by comission cost, which is paid in MoC'
-        //   );
+          mocHelper.assertBig(
+            diff,
+            0,
+            'RBTC balance should not decrease by comission cost, which is paid in MoC'
+          );
 
-        //   mocHelper.assertBig(
-        //     diffCommissionMoC,
-        //     expectedMoCCommission,
-        //     'Balance in MoC does not decrease by 0.045 MoC'
-        //   );
-        // });
-        // it('AND commissions account increase balance by 0.0045 MoC', async function() {
-        //   const commissionsAccountMoCBalance = await mocHelper.getMoCBalance(commissionsAccount);
-        //   const expectedMoCCommission = 4500000000000000;
-        //   const diff = new BN(commissionsAccountMoCBalance).sub(new BN(prevCommissionsAccountMoCBalance));
+          mocHelper.assertBig(
+            diffCommissionMoC,
+            expectedMoCCommission,
+            'Balance in MoC does not decrease by 0.045 MoC'
+          );
+        });
+        it('AND commissions account increase balance by 0.0045 MoC', async function() {
+          const commissionsAccountMoCBalance = await mocHelper.getMoCBalance(commissionsAccount);
+          const expectedMoCCommission = '4500000000000000';
+          const diff = new BN(commissionsAccountMoCBalance).sub(
+            new BN(prevCommissionsAccountMoCBalance)
+          );
 
-        //   console.log("prevCommissionsAccountMoCBalance: ", prevCommissionsAccountMoCBalance.toString());
-        //   console.log("commissionsAccountMoCBalance: ", commissionsAccountMoCBalance.toString());
-        //   console.log("diff: ", diff.toString());
+          console.log("prevCommissionsAccountMoCBalance: ", prevCommissionsAccountMoCBalance.toString());
+          console.log("commissionsAccountMoCBalance: ", commissionsAccountMoCBalance.toString());
+          console.log("diff: ", diff.toString());
 
-        //   mocHelper.assertBigRBTC(
-        //     diff,
-        //     expectedMoCCommission,
-        //     'Balance in MoC does not increase by 0.0045 RBTC'
-        //   );
-        // });
+          mocHelper.assertBig(
+            diff.toString(),
+            expectedMoCCommission,
+            'Balance in MoC does not increase by 0.0045 RBTC'
+          );
+        });
       });
     });
 

--- a/test/moc/commissions/MoCFreeDocsWithCommissions-test.js
+++ b/test/moc/commissions/MoCFreeDocsWithCommissions-test.js
@@ -29,7 +29,8 @@ contract('MoC', function([owner, userAccount, commissionsAccount]) {
             docsToRedeem: 100,
             commissionsRate: 4, // REDEEM_DOC_FEES_RBTC = 0.004
             bproToMint: 1,
-            mocAmount: 0
+            mocAmount: 0,
+            initialBtcPrice: 10000
           },
           expect: {
             docsToRedeem: 100,
@@ -46,7 +47,8 @@ contract('MoC', function([owner, userAccount, commissionsAccount]) {
             docsToMint: 500,
             docsToRedeem: 600,
             commissionsRate: 0.2,
-            bproToMint: 1
+            bproToMint: 1,
+            initialBtcPrice: 10000
           },
           expect: {
             docsToRedeem: 500,
@@ -62,7 +64,8 @@ contract('MoC', function([owner, userAccount, commissionsAccount]) {
             docsToMint: 1000,
             docsToRedeem: 100,
             commissionsRate: 0.2, //REDEEM_DOC_FEES_MOC
-            bproToMint: 1
+            bproToMint: 1,
+            initialBtcPrice: 10000
           },
           expect: {
             docsToRedeem: 100,
@@ -77,7 +80,8 @@ contract('MoC', function([owner, userAccount, commissionsAccount]) {
             docsToMint: 500,
             docsToRedeem: 600,
             commissionsRate: 0.2,
-            bproToMint: 1
+            bproToMint: 1,
+            initialBtcPrice: 10000
           },
           expect: {
             docsToRedeem: 500,

--- a/test/testHelpers/contractsBuilder.js
+++ b/test/testHelpers/contractsBuilder.js
@@ -1,5 +1,6 @@
 const { TestHelper } = require('zos');
 const { Contracts, ZWeb3 } = require('zos-lib');
+const BigNumber = require('bignumber.js');
 
 ZWeb3.initialize(web3.currentProvider);
 
@@ -100,51 +101,75 @@ const initializeCommissionRatesArray = async (moc, mocInrate) => {
   const ret = [
     {
       txType: (await mocInrate.MINT_BPRO_FEES_RBTC()).toString(),
-      fee: (0.001 * mocPrecision).toString()
+      fee: BigNumber(0.001)
+        .times(mocPrecision)
+        .toString()
     },
     {
       txType: (await mocInrate.REDEEM_BPRO_FEES_RBTC()).toString(),
-      fee: (0.002 * mocPrecision).toString()
+      fee: BigNumber(0.002)
+        .times(mocPrecision)
+        .toString()
     },
     {
       txType: (await mocInrate.MINT_DOC_FEES_RBTC()).toString(),
-      fee: (0.003 * mocPrecision).toString()
+      fee: BigNumber(0.003)
+        .times(mocPrecision)
+        .toString()
     },
     {
       txType: (await mocInrate.REDEEM_DOC_FEES_RBTC()).toString(),
-      fee: (0.004 * mocPrecision).toString()
+      fee: BigNumber(0.004)
+        .times(mocPrecision)
+        .toString()
     },
     {
       txType: (await mocInrate.MINT_BTCX_FEES_RBTC()).toString(),
-      fee: (0.005 * mocPrecision).toString()
+      fee: BigNumber(0.005)
+        .times(mocPrecision)
+        .toString()
     },
     {
       txType: (await mocInrate.REDEEM_BTCX_FEES_RBTC()).toString(),
-      fee: (0.006 * mocPrecision).toString()
+      fee: BigNumber(0.006)
+        .times(mocPrecision)
+        .toString()
     },
     {
       txType: (await mocInrate.MINT_BPRO_FEES_MOC()).toString(),
-      fee: (0.007 * mocPrecision).toString()
+      fee: BigNumber(0.007)
+        .times(mocPrecision)
+        .toString()
     },
     {
       txType: (await mocInrate.REDEEM_BPRO_FEES_MOC()).toString(),
-      fee: (0.008 * mocPrecision).toString()
+      fee: BigNumber(0.008)
+        .times(mocPrecision)
+        .toString()
     },
     {
       txType: (await mocInrate.MINT_DOC_FEES_MOC()).toString(),
-      fee: (0.009 * mocPrecision).toString()
+      fee: BigNumber(0.009)
+        .times(mocPrecision)
+        .toString()
     },
     {
       txType: (await mocInrate.REDEEM_DOC_FEES_MOC()).toString(),
-      fee: (0.0001 * mocPrecision).toString()
+      fee: BigNumber(0.0001)
+        .times(mocPrecision)
+        .toString()
     },
     {
       txType: (await mocInrate.MINT_BTCX_FEES_MOC()).toString(),
-      fee: (0.00011 * mocPrecision).toString()
+      fee: BigNumber(0.00011)
+        .times(mocPrecision)
+        .toString()
     },
     {
       txType: (await mocInrate.REDEEM_BTCX_FEES_MOC()).toString(),
-      fee: (0.00012 * mocPrecision).toString()
+      fee: BigNumber(0.00012)
+        .times(mocPrecision)
+        .toString()
     }
   ];
   return ret;

--- a/test/testHelpers/functionHelper.js
+++ b/test/testHelpers/functionHelper.js
@@ -1,6 +1,6 @@
 const { BigNumber } = require('bignumber.js');
 const chai = require('chai');
-const { toContract } = require('../../utils/numberHelper');
+const { toContract, toBigNumber } = require('../../utils/numberHelper');
 const { toContractBNNoPrec } = require('./formatHelper');
 
 // Changers
@@ -137,18 +137,22 @@ const mintDocAmount = (moc, btcPriceProvider, mocInrate) => async (account, docs
   }
   const reservePrecision = await moc.getReservePrecision();
   const mocPrecision = await moc.getMocPrecision();
-  const formattedAmount = docsToMint * mocPrecision;
+  const formattedAmount = toBigNumber(docsToMint).times(mocPrecision);
   const btcPrice = await getBitcoinPrice(btcPriceProvider)();
-  const btcTotal = (formattedAmount / btcPrice) * reservePrecision;
+  const btcTotal = formattedAmount.div(btcPrice).times(reservePrecision);
   // Sent more to pay commissions: if RBTC fees are used then get commission value,
   // otherwise commission is 0 RBTC
   const commissionRate = txType.eq(await mocInrate.MINT_DOC_FEES_RBTC())
     ? await mocInrate.commissionRatesByTxType(txType)
     : 0;
 
-  const commissionRbtcAmount = commissionRate > 0 ? (btcTotal * commissionRate) / mocPrecision : 0;
-  const value = toContract(btcTotal + commissionRbtcAmount);
-
+  const commissionRbtcAmount =
+    commissionRate > 0
+      ? toBigNumber(btcTotal)
+          .times(commissionRate)
+          .div(mocPrecision)
+      : 0;
+  const value = toContract(btcTotal.plus(commissionRbtcAmount));
   return moc.mintDoc(toContract(btcTotal), { from: account, value });
 };
 


### PR DESCRIPTION
Remove unused variable prevCommissionsAccountBtcBalance
Use string on large numbers to prevent js to make precision errors
avoid mixing BN.js with BigNumber.js as they have sutil diferent behaviours
Add initialBtcPrice to scenario in MocFreeDocsWithComission